### PR TITLE
fix topic construction issue

### DIFF
--- a/permission.js
+++ b/permission.js
@@ -1,25 +1,34 @@
 /**
- * Resolves the given partial topics into an array of topic levels
- * @param  {(string|number)[] | string | number} partialTopics 
- * @returns {string[]} the sanitized topic levels
+ * Resolves the given partial topics into an array of topic levels.
+ * This function takes one or more topic parts, which can be strings, numbers, or arrays,
+ * and sanitizes them into a flat array of topic levels.
+ * 
+ * @param  {(string|number)[] | string | number} partialTopics - The topic parts to resolve.
+ * @returns {string[]} The sanitized topic levels as an array of strings.
  */
 export const resolveTopic = (...partialTopics) => {
 	const topic = [];
 
+	// Iterate over each part of the provided topics
 	for (let part of partialTopics) {
+		// Skip undefined, null, or empty string values
 		if (part === undefined || part === null || part === '') continue;
 
+		// If the part is a string containing '/', split it into an array of levels
 		if (typeof part === 'string' && part.includes('/')) {
 			part = part.split('/');
 		}
 
+		// If the part is an array, recursively resolve its elements
 		if (Array.isArray(part)) {
 			topic.push(...resolveTopic(...part));
 		} else {
+			// Otherwise, add the part to the topic array
 			topic.push(part);
 		}
 	}
 
+	// Return the resolved topic levels as a flat array
 	return topic;
 }
 

--- a/permission.js
+++ b/permission.js
@@ -1,4 +1,29 @@
 /**
+ * Resolves the given partial topics into an array of topic levels
+ * @param  {(string|number)[] | string | number} partialTopics 
+ * @returns {string[]} the sanitized topic levels
+ */
+export const resolveTopic = (...partialTopics) => {
+	const topic = [];
+
+	for (let part of partialTopics) {
+		if (part === undefined || part === null || part === '') continue;
+
+		if (typeof part === 'string' && part.includes('/')) {
+			part = part.split('/');
+		}
+
+		if (Array.isArray(part)) {
+			topic.push(...resolveTopic(...part));
+		} else {
+			topic.push(part);
+		}
+	}
+
+	return topic;
+}
+
+/**
  * Given the provided ACLs, and user, find the ACLs that the user has subscribe (or publish) permissions for.
  * @param acls - The list of ACLs that could apply to a topic
  * @param user - The user object
@@ -9,7 +34,7 @@ export function findTopicsForUser(acls, user, client_id, publish = false) {
 	return acls.map(acl => {
 		const acl_groups = acl[publish ? 'publishers' : 'subscribers'];
 		let user_groups = [];
-		if(user) {
+		if (user) {
 			user_groups = user.authGroups || user.role?.role;
 		}
 		// It appears that the convention for auth groups is to use a semicolon to separate groups

--- a/test/permission.js
+++ b/test/permission.js
@@ -1,82 +1,94 @@
-import {describe, it} from 'node:test';
-import {mqttPermissionCheck} from '../permission.js';
+import { describe, it } from 'node:test';
+import { mqttPermissionCheck, resolveTopic } from '../permission.js';
 import assert from "node:assert";
 
-describe('Test mqttPermissionCheck', ()=>{
+describe('Test mqttPermissionCheck', () => {
 
-  it('test liberty/scott/# expect false', ()=>{
-    let result = mqttPermissionCheck(['liberty','scott','#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/scott/# expect false', () => {
+    let result = mqttPermissionCheck(['liberty', 'scott', '#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, false);
   });
 
-  it('test liberty/scott expect false', ()=>{
-    let result = mqttPermissionCheck(['liberty','scott'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/scott expect false', () => {
+    let result = mqttPermissionCheck(['liberty', 'scott'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, false);
   });
 
-  it('test liberty/# expect false', ()=>{
-    let result = mqttPermissionCheck(['liberty','#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/# expect false', () => {
+    let result = mqttPermissionCheck(['liberty', '#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, false);
   });
 
-  it('test liberty/bill/+ expect false', ()=>{
-    let result = mqttPermissionCheck(['liberty','bill','+'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/bill/+ expect false', () => {
+    let result = mqttPermissionCheck(['liberty', 'bill', '+'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, false);
   });
 
-  it('test liberty/scott/+ expect true', ()=>{
-    let result = mqttPermissionCheck(['liberty','scott','+'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/scott/+ expect true', () => {
+    let result = mqttPermissionCheck(['liberty', 'scott', '+'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, false);
   });
 
-  it('test liberty/scott/+/tmp expect true', ()=>{
-    let result = mqttPermissionCheck(['liberty','scott','+', 'tmp'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/scott/+/tmp expect true', () => {
+    let result = mqttPermissionCheck(['liberty', 'scott', '+', 'tmp'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, true);
   });
 
-  it('test liberty/scott/hi/tmp expect true', ()=>{
-    let result = mqttPermissionCheck(['liberty','scott','hi', 'tmp'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/scott/hi/tmp expect true', () => {
+    let result = mqttPermissionCheck(['liberty', 'scott', 'hi', 'tmp'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, true);
   });
 
-  it('test liberty/scott/hi/tmp/bad expect false', ()=>{
-    let result = mqttPermissionCheck(['liberty','scott','hi', 'tmp', 'bad'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/scott/hi/tmp/bad expect false', () => {
+    let result = mqttPermissionCheck(['liberty', 'scott', 'hi', 'tmp', 'bad'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, false);
   });
 
-  it('test liberty/scott/tmp expect true', ()=>{
-    let result = mqttPermissionCheck(['liberty','scott','tmp'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/scott/tmp expect true', () => {
+    let result = mqttPermissionCheck(['liberty', 'scott', 'tmp'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, false);
   });
 
-  it('test liberty/testing/# expect true', ()=>{
-    let result = mqttPermissionCheck(['liberty','testing','#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/testing/# expect true', () => {
+    let result = mqttPermissionCheck(['liberty', 'testing', '#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, true);
   });
 
-  it('test liberty/# expect false', ()=>{
-    let result = mqttPermissionCheck(['liberty','#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/# expect false', () => {
+    let result = mqttPermissionCheck(['liberty', '#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, false);
   });
 
-  it('test liberty/testing/cool expect true', ()=>{
-    let result = mqttPermissionCheck(['liberty','testing','cool'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/testing/cool expect true', () => {
+    let result = mqttPermissionCheck(['liberty', 'testing', 'cool'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, true);
   });
 
-  it('test liberty/testing/cool/cooler/coolest expect true', ()=>{
-    let result = mqttPermissionCheck(['liberty','testing','cool','cooler','coolest'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/testing/cool/cooler/coolest expect true', () => {
+    let result = mqttPermissionCheck(['liberty', 'testing', 'cool', 'cooler', 'coolest'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, true);
   });
 
-  it('test liberty/testing/cool/# expect true', ()=>{
-    let result = mqttPermissionCheck(['liberty','testing','cool','#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test liberty/testing/cool/# expect true', () => {
+    let result = mqttPermissionCheck(['liberty', 'testing', 'cool', '#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, true);
   });
 
-  it('test nogood/testing/cool/# expect false', ()=>{
-    let result = mqttPermissionCheck(['nogood','testing','cool','#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
+  it('test nogood/testing/cool/# expect false', () => {
+    let result = mqttPermissionCheck(['nogood', 'testing', 'cool', '#'], [['liberty', 'scott', '+', '+'], ['liberty', 'testing', '#']]);
     assert.equal(result, false);
   });
 
 });
+
+
+describe('Test resolveTopic', () => {
+  it("test ('events', ['a/b']) => ['events', 'a', 'b']", () => {
+    let result = resolveTopic('events', ['a/b']);
+    assert.deepStrictEqual(result, ['events', 'a', 'b']);
+  });
+  it("test ('events', ['a','b']) => ['events', 'a', 'b']", () => {
+    let result = resolveTopic('events', ['a', 'b']);
+    assert.deepStrictEqual(result, ['events', 'a', 'b']);
+  });
+})


### PR DESCRIPTION
There have been various changes to the handling of multi-level, path-like ids between 4.3 and 4.4, namely https://github.com/HarperDB/harperdb/commit/f99ba751c70ed0e58a30cb58295ddca7986414b4. This has caused a resource's id to be `['1', '2']` in 4.3 but `['1/2']`(by default) since 4.4.6. I tried setting `splitSegments` to `true`, which did make the paths come back split, but other issues arose for subscriptions to those ids when using `#`. So, instead of trying to fix how the ids were parsed and set, I realized we can just accept the id in either format and "resolve" it into what the `mqttPermissionCheck` function expects: an array of topic levels. So, if an id comes back as `['1', '2']`, we would leave it as is. But if it comes back as `['1/2']`, we would split it into `['1', '2']` to match the original behavior.